### PR TITLE
Fix a few grammar issues in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,64 @@
 # minetest-game-whynot
-Game for Minetest in mods collection style
 
-This game show up the diversity of minetest community. The game does not follow any theme and does not try to clone any other blocky game, just minetest as known in community.
+A Game for MineTest in mod-collection style
+
+This game shows the diversity of the MineTest community. The game does not follow any theme and does not try to clone any other blocky game, just minetest as known in community.
 
 The name describes the way the mods are applied to the game. The game does not have rules for mods to be applied, all mods are welcome. But there are some rules why a mod cannot be applied to the game.
 
 ### List of already included mods
+
 Generated file: [mod_sources.txt](https://github.com/bell07/minetest-game-whynot/blob/master/mod_sources.txt)
 
 ### License statement
-Each mods does have own free license.
-The whynot related work (buiding scripts) are GPL-V3 
+
+Each mods does have their own free license.
+The whynot related work (such as the buiding scripts) are GPL-V3
 
 ## Whynot Rules for mods
 
-### 1 no take over the game
-unfortunately a lot of great mods assumes the player like to play with this mod only. This game stands for diversity. That means if a player do not like an included mod, he can play the game without using them (few exceptions)
+### 1 don't take over the game
 
-### 2 no take over the server
-Think ahead the point 1 the mod should be not strain the server if the mod is not in use. That means no unnecessary ABM's and so on
+<span id="#1-no-take-over-the-game"></span>
 
-### 3 no destroy the world
-The mod should not be able to destroy players work
+Unfortunately a lot of great mods assume the player likes to play with this mod only. This game stands for diversity. That means if a player does not like an included mod, they can play the game without using that mod (few exceptions).
+
+### 2 don't take over the server
+
+<span id="#2-no-take-over-the-server"></span>
+
+Thinking alongside point 1, the mod should be not strain the server if the mod is not in use. That means no unnecessary ABM's and so on.
+
+### 3 don't destroy the world
+
+<span id="#3-no-destroy-the-world"></span>
+
+The mod should not be able to destroy players' work.
 
 ### 4 no bad code quality
-I look into lua code of each mod before decision. I am tolerant against not perfect code, but roughly negligent bad code will be rejected. Advantage for the mod developer: Code review for free ;-) And if I like the mod, maybe I contribute some optimization lines to get the mod ready for the game
 
-### 5 no all-in-one mods and lot of unused dependencies
-It is difficult to consider an all-in-one mod for described rules. Therefore maybe an all-in-one mod will be rejected
+<span id="#4-no-bad-code-quality"></span>
+
+I look into the lua code of each mod before I make my decision. I am tolerant against imperfect code, but roughly negligent and/or bad code will be rejected. Advantage for the mod developer: They get a code review for free ;-) And if I like the mod, I might contribute some optimizations to get the mod ready for the game.
+
+### 5 no all-in-one mods or lots of unused dependencies
+
+<span id="#5-no-all-in-one-mods-and-lot-of-unused-dependencies"></span>
+
+It is difficult to consider an all-in-one mod for these described rules. Therefore an all-in-one mod might be rejected.
 
 ### 6 most items obtainable in survival
+
 The game should be playable in survival. Therefore the items should be obtainable
 
 ### 7 No cheating mods
-The mods should not be feels like cheats. The tools should be weared, the walking the world and searching for rare items should not be obsolete by item generators.
+
+The mods should not feel like cheats. The tools should be worn, walking through the world and searching for rare items should not be made obsolete by item generators.
 
 ### 8 Mod under version control
-This game is not a new home for mods. Each mod remains and have own upstream. access by version control required for scripted updates to the game. If bugs found in mods in game, please report them to the upstream
+
+This game is not a new home for mods. Each mod remains within and have their own upstream. Access by version control is required for scripted updates to the game. If bugs are found in mods in this game, please report them to the upstream sources.
 
 ## How to include a new mod to this game
-Just open a new issue in github-repository https://github.com/bell07/minetest-game-whynot. Mod will be reviewed and included or a discussion started if a whynot rule appears
 
+Just open a new issue in the github-repository <https://github.com/bell07/minetest-game-whynot>. The mod will be reviewed and included or a discussion started if a whynot rule appears.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Generated file: [mod_sources.txt](https://github.com/bell07/minetest-game-whynot
 
 ### License statement
 
-Each mods does have their own free license.
+Each of the mods do have their own free license.
 The whynot related work (such as the buiding scripts) are GPL-V3
 
 ## Whynot Rules for mods
@@ -36,8 +36,6 @@ Thinking alongside point 1, the mod should be not strain the server if the mod i
 The mod should not be able to destroy players' work.
 
 ### 4 no bad code quality
-
-<span id="4-no-bad-code-quality"></span>
 
 I look into the lua code of each mod before I make my decision. I am tolerant against imperfect code, but roughly negligent and/or bad code will be rejected. Advantage for the mod developer: They get a code review for free ;-) And if I like the mod, I might contribute some optimizations to get the mod ready for the game.
 

--- a/README.md
+++ b/README.md
@@ -19,31 +19,31 @@ The whynot related work (such as the buiding scripts) are GPL-V3
 
 ### 1 don't take over the game
 
-<span id="#1-no-take-over-the-game"></span>
+<span id="1-no-take-over-the-game"></span>
 
 Unfortunately a lot of great mods assume the player likes to play with this mod only. This game stands for diversity. That means if a player does not like an included mod, they can play the game without using that mod (few exceptions).
 
 ### 2 don't take over the server
 
-<span id="#2-no-take-over-the-server"></span>
+<span id="2-no-take-over-the-server"></span>
 
 Thinking alongside point 1, the mod should be not strain the server if the mod is not in use. That means no unnecessary ABM's and so on.
 
 ### 3 don't destroy the world
 
-<span id="#3-no-destroy-the-world"></span>
+<span id="3-no-destroy-the-world"></span>
 
 The mod should not be able to destroy players' work.
 
 ### 4 no bad code quality
 
-<span id="#4-no-bad-code-quality"></span>
+<span id="4-no-bad-code-quality"></span>
 
 I look into the lua code of each mod before I make my decision. I am tolerant against imperfect code, but roughly negligent and/or bad code will be rejected. Advantage for the mod developer: They get a code review for free ;-) And if I like the mod, I might contribute some optimizations to get the mod ready for the game.
 
 ### 5 no all-in-one mods or lots of unused dependencies
 
-<span id="#5-no-all-in-one-mods-and-lot-of-unused-dependencies"></span>
+<span id="5-no-all-in-one-mods-and-lot-of-unused-dependencies"></span>
 
 It is difficult to consider an all-in-one mod for these described rules. Therefore an all-in-one mod might be rejected.
 


### PR DESCRIPTION
You may have noticed the addition of a few `span` html elements. This is to ensure that any links to a header I changed still link to the correct area of the document. (Wikipedia does this automatically, but github doesn't) I did test this - they do work.

If you don't like any of these changes feel free to edit this PR.